### PR TITLE
Add colors to the Django logger

### DIFF
--- a/grader/settings.py
+++ b/grader/settings.py
@@ -163,18 +163,23 @@ ENABLE_PERSONAL_DIRECTORIES = False
 # Logging
 # https://docs.djangoproject.com/en/1.7/topics/logging/
 ##########################################################################
+from colorlog import ColoredFormatter
+
 LOGGING = {
   'version': 1,
   'disable_existing_loggers': False,
+  # Formatters configuration
   'formatters': {
     'verbose': {
-      'format': '[%(asctime)s: %(levelname)s/%(module)s] %(message)s'
+      '()': 'colorlog.ColoredFormatter',
+      'format': '%(log_color)s[%(asctime)s: %(levelname)s/%(module)s] %(message)s',
     },
   },
+  # Handlers configuration
   'handlers': {
     'console': {
       'level': 'DEBUG',
-      'class': 'logging.StreamHandler',
+      'class': 'colorlog.StreamHandler',
       'stream': 'ext://sys.stdout',
       'formatter': 'verbose',
     },
@@ -183,6 +188,7 @@ LOGGING = {
       'class': 'django.utils.log.AdminEmailHandler',
     },
   },
+  # Loggers Configuration
   'loggers': {
     '': {
       'level': 'DEBUG',
@@ -195,9 +201,6 @@ LOGGING = {
     },
   },
 }
-
-
-
 
 
 ###############################################################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ lxml ~= 4.3.2
 PyYAML==3.11
 docutils==0.12
 python-magic==0.4.11
+colorlog==4.1.0


### PR DESCRIPTION
# Description

This colored logger allows detecting the different events more easily during debugging. 

The default colors defined in colorlog==4.1.0 are used:
* INFO = green
* WARNING = yellow
* ERROR = red
* CRITICAL = red, bg_white

![logger](https://user-images.githubusercontent.com/10437475/78504250-8042e200-7774-11ea-9872-6b45aa3fb2dd.png)


# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [X] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [X] Not relevant
