### PR TITLE
Questionnaire feedback summary - changes in mooc-grader

### DIFF
--- a/access/templates/access/_error_summary.html
+++ b/access/templates/access/_error_summary.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+
+
+<div class="error-summary">
+	<div class="error-summary__text">
+		<h4>{% trans "Submission failed" %}</h4>
+		<p>{% trans "Check your answers before trying again:" %}</p>
+		{% for field in result.form %}
+			{% if field.errors %}
+				<p>{{ field.label }}:
+				{% for error in field.errors %}
+					{{ error }}
+				{% endfor %}
+				</p>
+			{% endif %}
+		{% endfor %}
+	</div>
+</div>

--- a/access/templates/access/create_form_default.html
+++ b/access/templates/access/create_form_default.html
@@ -13,7 +13,7 @@
 			<p>{{ exercise.accepted_message|safe }}</p>
 		{% endif %}
 		<p>
-			{% blocktrans %}
+			{% blocktrans trimmed %}
 				The whole section within the black line is marked as being
 				incorrect, if one of the questions incorrect.
 			{% endblocktrans %}

--- a/access/templates/access/create_form_default.html
+++ b/access/templates/access/create_form_default.html
@@ -3,32 +3,10 @@
 
 {% block exercise %}
 
-{% if result.accepted %}
-<div class="alert {% if result.error_fields %}alert-danger{% else %}alert-success{% endif %}">
-<p>
-    {% if exercise.accepted_message %}
-    {{ exercise.accepted_message|safe }}
-    {% else %}
-    {% blocktrans with points=result.points max_points=exercise.max_points %}
-    You got {{ points }}/{{ max_points }} points from this questionnaire.
-    {% endblocktrans %}
-    {% endif %}
-</p>
-<p>
-    {% if result.form.group_errors %}
-    {% blocktrans %}
-    Note that the whole section of questions is marked as being incorrect if
-    one of the questions in that section is incorrect.
-    {% endblocktrans %}
-    {% endif %}
-    {% if not result.form.disabled and result.points < exercise.max_points %}
-    {% blocktrans %}
-    You can change your answers and submit them for regrading.
-    However, notice the number of allowed submissions left!
-    {% endblocktrans %}
-    {% endif %}
-</p>
-</div>
+{% if result.accepted and exercise.accepted_message %}
+  <div class="alert alert-default">
+    <p>{{ exercise.accepted_message|safe }}</p>
+  </div>
 {% endif %}
 
 {% if exercise.instructions %}

--- a/access/templates/access/create_form_default.html
+++ b/access/templates/access/create_form_default.html
@@ -7,6 +7,18 @@
 	<div class="alert alert-default">
 		<p>{{ exercise.accepted_message|safe }}</p>
 	</div>
+{% elif result.accepted and result.form.group_errors %}
+	<div class="alert alert-default">
+		{% if exercise.accepted_message|safe %}
+			<p>{{ exercise.accepted_message|safe }}</p>
+		{% endif %}
+		<p>
+			{% blocktrans %}
+				The whole section within the black line is marked as being
+				incorrect, if one of the questions incorrect.
+			{% endblocktrans %}
+		</p>
+	</div>
 {% elif result.form.errors %}
 	{% include "access/_error_summary.html" %}
 {% endif %}

--- a/access/templates/access/create_form_default.html
+++ b/access/templates/access/create_form_default.html
@@ -4,18 +4,20 @@
 {% block exercise %}
 
 {% if result.accepted and exercise.accepted_message %}
-  <div class="alert alert-default">
-    <p>{{ exercise.accepted_message|safe }}</p>
-  </div>
+	<div class="alert alert-default">
+		<p>{{ exercise.accepted_message|safe }}</p>
+	</div>
+{% elif result.form.errors %}
+	{% include "access/_error_summary.html" %}
 {% endif %}
 
 {% if exercise.instructions %}
 <div class="instructions">
-  {{ exercise.instructions|safe }}
+	{{ exercise.instructions|safe }}
 </div>
 {% endif %}
 {% if exercise.instructions_file %}
-  {% include exercise.instructions_file %}
+	{% include exercise.instructions_file %}
 {% endif %}
 
 {% include 'access/graded_form.html' %}

--- a/access/templates/access/graded_form.html
+++ b/access/templates/access/graded_form.html
@@ -9,8 +9,8 @@
 	{% for field in result.form %}
 
 	{% if field.field.open_set %}
-	<!-- Beginning of all questions -->
-		<fieldset id="{{ field.field.open_set }}">
+		<!-- Beginning of all questions -->
+		<fieldset id="{{ field.field.open_set }}"{% if result.accepted and field.field.group_errors %} class="alert alert-default"{% endif %}>
 		{% if field.field.set_title %}<legend>{{ field.field.set_title }}</legend>{% endif %}
 	{% endif %}
 

--- a/access/types/forms.py
+++ b/access/types/forms.py
@@ -238,19 +238,6 @@ class GradedForm(forms.Form):
         if self.disabled:
             args['widget'].attrs['disabled'] = 'disabled'
 
-        if args['required'] and (
-            widget_class is not forms.CheckboxSelectMultiple or len(choices) == 1
-        ):
-            # The required HTML attribute should not be set to a question with
-            # multiple checkboxes since the browser would require that the user
-            # selects every checkbox.
-            # Note: newer Django versions include the required HTML attribute
-            # automatically when the "required" parameter is given to the Field
-            # constructor (like is done here with the args variable).
-            # When Django is upgraded, we don't need to set the "required" attr
-            # to the widget here anymore.
-            args['widget'].attrs['required'] = True
-
         name = self.field_name(i, config)
         selected_choices = choices
         correct_choices = correct

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MOOC-grader\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-28 09:01+0000\n"
+"POT-Creation-Date: 2020-08-14 13:07+0000\n"
 "PO-Revision-Date: 2019-10-12 20:00+0300\n"
 "Last-Translator: Saara Satokangas <saara.satokangas@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -15,6 +15,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: access/templates/access/_error_summary.html:6
+#: access/templates/access/async_accepted.html:18
+msgid "Submission failed"
+msgstr "Palautuksen vastaanottaminen epäonnistui"
+
+#: access/templates/access/_error_summary.html:7
+msgid "Check your answers before trying again:"
+msgstr "Tarkista vastauksesi ja yritä uudelleen:"
 
 #: access/templates/access/accept_files_default.html:8
 msgid "Select your files for grading"
@@ -34,7 +43,7 @@ msgstr ""
 #: access/templates/access/accept_general_form.html:42
 #: access/templates/access/accept_git_form.html:16
 #: access/templates/access/accept_post_form.html:17
-#: access/templates/access/graded_form.html:192
+#: access/templates/access/graded_form.html:197
 msgid "Submit"
 msgstr "Lähetä"
 
@@ -119,10 +128,6 @@ msgstr ""
 "synkronisesti, mikä estää muita palveluja toimimasta samaan aikaan. EI "
 "VALMIS TUOTANTOKÄYTTÖÖN!"
 
-#: access/templates/access/async_accepted.html:18
-msgid "Submission failed"
-msgstr "Palautuksen vastaanottaminen epäonnistui"
-
 #: access/templates/access/async_accepted.html:20
 msgid ""
 "\n"
@@ -204,38 +209,12 @@ msgstr "Vaatii gitmanager-liitännäisen"
 msgid "Available exercises"
 msgstr "Saatavilla olevat tehtävät"
 
-#: access/templates/access/create_form_default.html:12
-#, python-format
+#: access/templates/access/create_form_default.html:16
 msgid ""
-"\n"
-"    You got %(points)s/%(max_points)s points from this questionnaire.\n"
-"    "
-msgstr ""
-"\n"
-"Sait %(points)s/%(max_points)s pistettä tästä tehtävästä."
-
-#: access/templates/access/create_form_default.html:19
-msgid ""
-"\n"
-"    Note that the whole section of questions is marked as being incorrect "
-"if\n"
-"    one of the questions in that section is incorrect.\n"
-"    "
-msgstr ""
-"\n"
-"Huomaa, että koko kysymysosio merkitään virheelliseksi, jos yksikin osion\n"
-"vastauksista on virheellinen."
-
-#: access/templates/access/create_form_default.html:25
-msgid ""
-"\n"
-"    You can change your answers and submit them for regrading.\n"
-"    However, notice the number of allowed submissions left!\n"
-"    "
-msgstr ""
-"\n"
-"Voit vaihtaa vastauksiasi ja lähettää ne uudelleen arvosteltavaksi.\n"
-"Huomaa kuitenkin jäljellä olevien palautuskertojen määrä!"
+"The whole section within the black line is marked as being incorrect, if one "
+"of the questions incorrect."
+msgstr "Kaikki kysymykset kysymysosion sisällä merkitään vääriksi vastauksiksi "
+"mikäli yksi kysymyksistä on väärin."
 
 #: access/templates/access/exercise_config_error.html:6
 msgid ""
@@ -306,16 +285,16 @@ msgstr ""
 "    </p>\n"
 "    "
 
-#: access/templates/access/graded_form.html:44
+#: access/templates/access/graded_form.html:49
 #: access/templates/access/graded_form_feedback.html:20
 msgid "Incorrect"
 msgstr "Vastauksesi on väärin."
 
-#: access/templates/access/graded_form.html:46
+#: access/templates/access/graded_form.html:51
 msgid "Correct"
 msgstr "Oikein"
 
-#: access/templates/access/graded_form.html:54
+#: access/templates/access/graded_form.html:59
 #, python-format
 msgid ""
 "\n"
@@ -414,14 +393,14 @@ msgstr ""
 "Pahoittelemme häiriötä.\n"
 "Yritä myöhemmin uudelleen tai ota yhteyttä kurssihenkilökuntaan."
 
-#: access/types/forms.py:644
+#: access/types/forms.py:639
 msgid "Multiple choices are selectable"
 msgstr "Voit valita useita vaihtoehtoja"
 
-#: access/types/forms.py:830
+#: access/types/forms.py:825
 msgid "Multiple correct answers accepted."
 msgstr "Useita oikeita vastauksia."
 
-#: access/types/forms.py:834
+#: access/types/forms.py:829
 msgid "Correct parts in your answer: "
 msgstr "Oikeat osat vastauksessasi: "


### PR DESCRIPTION
# Description

~~Preferably not to be merged before: https://github.com/apluslms/mooc-grader/pull/76~~

Related to the changes in: https://github.com/apluslms/a-plus/pull/637

Fixes: https://github.com/apluslms/a-plus/issues/592 

Related also to solving: https://github.com/apluslms/a-plus/issues/593 and https://github.com/apluslms/a-plus/issues/591 

**1. Implements auto_id for questionnaire fields.**
- The auto_id contains a random string as a separating factor for different fields. 
- This has been done for the cases where there are multiple questionnaires on the same page, this separates the fields of those questionnaires for better accessibility, and also makes handling errors on the front-end easier. 

**2. Removes the required-attr addition from questionnaire widgets** 
- Now that Django has been updated, the widgets no longer needed the html-attribute of required set. So validation errors are handled all by Django for consistency. 

**3. Presents a validation error summary for the questionnaire:** 
- Previously the validation errors for questionnaires were mixed in with the errors presented of wrong answers. Those two were separated in: https://github.com/apluslms/mooc-grader/pull/76. This continues on that, by adding a validation error summary at the top of the questionnaire, which is recommended eg. in [here](https://design-system.service.gov.uk/patterns/validation/). If there are errors with the form and with the users input in those, those are showed.
- The html-template of [_error_summary.html](https://github.com/apluslms/mooc-grader/compare/master...saarasat:quiz-feedback-summary?expand=1#diff-88f59fe9e07c41e9751ba71bc6060a39) could be used later on for other exercise-types and their errors for continuity and easier handling of all mooc-grader errors, for example at:
https://github.com/apluslms/mooc-grader/blob/master/access/templates/access/exercise_frame.html
https://github.com/apluslms/mooc-grader/blob/master/access/templates/access/active_element_default.html
https://github.com/apluslms/mooc-grader/blob/master/access/templates/access/async_accepted.html
https://github.com/apluslms/mooc-grader/blob/master/access/templates/access/exercise_config_error.html

**4. Presents an initial style for possible wider user for (validation) error summaries** 
- The summary has been styled and worked on based on @mtthwhggns initial design. 
- **The design could be still easily worked on, if deemed somehow unfit. Or if the style is accepted, it could be adopted as a general replacement for the current bootstrap alert-danger, at least for the exercise-error** 

**5. Removes the duplicate information of points from questionnaire** 
- Additionally as the feedback for the student about wrong and right answers were improved in https://github.com/apluslms/mooc-grader/pull/76, this removes the now unnecessary duplicate information regarding the points of a questionnaire. If the teacher has set an accepted-message to be shown after a submission is accepted (regardless if the question is right or wrong), that will be shown with the default-alert.

**This pull request DOES NOT:** 
- Work on the exercises in general. This is just a proof of concept for the questionnaire on the error summary, and it could be then spread for wider use within the exercises. 

**Error summary. The error-message showing below the field is improved in https://github.com/apluslms/mooc-grader/pull/76**
![image](https://user-images.githubusercontent.com/43036333/89100245-399d8580-d3fe-11ea-90d5-ea69a97c3c07.png)

**Accepted message**
![image](https://user-images.githubusercontent.com/43036333/89100284-90a35a80-d3fe-11ea-8e5b-15ffa55fde07.png) 

# Testing

The changes have been tested manually and the existing automatic tests pass.

# Have you updated the README or other relevant documentation?

*Don't forget to update the documentation if it is relevant for this PR.*

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
