### PR TITLE
Neutral options

### DIFF
--- a/access/templates/access/graded_form.html
+++ b/access/templates/access/graded_form.html
@@ -125,26 +125,26 @@
 					{{ choice.tag }}
 					{{ choice.choice_label|safe }}
 				</label>
-				{% if not field.field.answer_correct %}
-					{# Marking the correct radio- or checkbox-options for after max-submissions, if "reveal-model" set to true and answer is not correct #}
-					{% if choice.choice_value in field.field.correct %}
+				{% if result.form.reveal_correct or result.model_answer %}
+					{# Indicating the correct and neutral answers and hiding hints, if the form is a model answer #}
+					{% if choice.choice_value in field.field.correct and not field.field.answer_correct %}
 						<i data-aplus-once="yes" class="quiz1-icon-correct" aria-hidden="true"></i>
 					{% elif choice.choice_value in field.field.neutral %}
 						<i data-aplus-once="yes" class="quiz1-icon-neutral" aria-hidden="true"></i>
 					{% endif %}
 					{# end of correct answer #}
-				{% endif %}
-
-				{% if field.field.type == "checkbox" and choice.choice_value in choice.value and field.field.hints %}
-					<div>
-						{% with hint=field.field.hints|find_checkbox_hints:choice.choice_value %}
-							{% if hint %}
-								<p class="question-hint hint-checkbox">
-									{{ hint|safe }}
-								</p>
-							{% endif %}
-						{% endwith %}
-					</div>
+				{% else %}
+					{% if field.field.type == "checkbox" and choice.choice_value in choice.value and field.field.hints %}
+						<div>
+							{% with hint=field.field.hints|find_checkbox_hints:choice.choice_value %}
+								{% if hint %}
+									<p class="question-hint hint-checkbox">
+										{{ hint|safe }}
+									</p>
+								{% endif %}
+							{% endwith %}
+						</div>
+					{% endif %}
 				{% endif %}
 			</div>
 			{% endfor %}

--- a/access/templates/access/graded_form.html
+++ b/access/templates/access/graded_form.html
@@ -126,11 +126,15 @@
 					{{ choice.choice_label|safe }}
 				</label>
 				{% if result.form.reveal_correct or result.model_answer %}
-					{# Indicating the correct and neutral answers and hiding hints, if the form is a model answer #}
+					{# Indicating the correct and neutral options and hiding hints, if the form is a model answer #}
 					{% if choice.choice_value in field.field.correct and not field.field.answer_correct %}
 						<i data-aplus-once="yes" class="quiz1-icon-correct" aria-hidden="true"></i>
 					{% elif choice.choice_value in field.field.neutral %}
-						<i data-aplus-once="yes" class="quiz1-icon-neutral" aria-hidden="true"></i>
+						{% if result.model_answer %}
+							<span><em>**{% trans "neutral option which does not affect grading"%}**</em></span>
+						{% elif result.form.reveal_correct and not field.field.answer_correct %}
+							<i data-aplus-once="yes" class="quiz1-icon-neutral" aria-hidden="true"></i>
+						{% endif %}
 					{% endif %}
 					{# end of correct answer #}
 				{% else %}

--- a/access/templates/access/graded_form.html
+++ b/access/templates/access/graded_form.html
@@ -161,7 +161,7 @@
 			<!-- End of a text-field -->
 			{% endif %}
 
-		{% if result.accepted and not result.form.show_correct and not field.field.row_label or field.field.close_table %}
+		{% if result.accepted and not result.model_answer and not field.field.row_label or field.field.close_table %}
 			<!-- Question feedback -->
 			<div>
 				{% if field.field.type == "checkbox" %}

--- a/access/templates/access/graded_form_feedback.html
+++ b/access/templates/access/graded_form_feedback.html
@@ -1,36 +1,42 @@
 {% load i18n %}
 
 
-{# if model answer is not be shown to the user, possible hints and default messages of correctness are shown instead #}
-{% if hints and not field.correct %}
-	{% for hint in hints  %}
-		<p class="question-hint hint-general">
-			{{ hint|safe }}
-		</p>
-	{% endfor %}
-{% endif %}
-<p class="question-feedback">
-	{% if field.answer_correct %}
-		<i class="quiz1-icon-correct"  aria-hidden="true"></i>
-		<span class="feedback-text">{% trans "Correct!" %}</span>
-	{% else %}
-		<i class="quiz1-icon-incorrect" aria-hidden="true"></i>
-		<span class="feedback-text">
-			{% if not field.correct %}
-				{% trans "Incorrect" %}
-			{% else %}
-			{# if "reveal-model after max-submissions" is set to true and user's answer is not correct, the model answer is shown #}
-				<span data-aplus-once="yes">
-					{% if field.type == "checkbox" or field.type == "radio" %}
-						{% trans "Incorrect. You can check the correct options above." %}
-						{% if field.neutral %}
-							{% trans "Neutral options which do not affect grading are marked with a question mark." %}
-						{% endif %}
-					{% else %}
-						{% trans "Incorrect. The correct answer is" %}: {{ field.correct }}
+{% if result.form.reveal_correct %}
+{# if "reveal-model-at-max-submissions" is set to true, the correct answers are revealed #}
+	<p data-aplus-once="yes" class="question-feedback">
+		{% if field.answer_correct %}
+			<i class="quiz1-icon-correct"  aria-hidden="true"></i>
+			<span class="feedback-text">{% trans "Correct!" %}</span>
+		{% else %}
+			<i class="quiz1-icon-incorrect" aria-hidden="true"></i>
+			<span>
+				{% if field.type == "checkbox" or field.type == "radio" %}
+					{% trans "Incorrect. You can check the correct options above." %}
+					{% if field.neutral %}
+						{% trans "Neutral options which do not affect grading are marked with a question mark." %}
 					{% endif %}
-				</span>
-			{% endif %}
-		</span>
+				{% else %}
+					{% trans "Incorrect. The correct answer is" %}: {{ field.correct }}
+				{% endif %}
+			</span>
+		{% endif %}
+	</p>
+{% else %}
+{# if "reveal-model-at-max-submissions" is not set, possible hints and default messages are shown instead #}
+	{% if hints and not field.answer_correct %}
+		{% for hint in hints  %}
+			<p class="question-hint hint-general">
+				{{ hint|safe }}
+			</p>
+		{% endfor %}
 	{% endif %}
-</p>
+	<p class="question-feedback">
+		{% if field.answer_correct %}
+			<i class="quiz1-icon-correct"  aria-hidden="true"></i>
+			<span class="feedback-text">{% trans "Correct!" %}</span>
+		{% else %}
+			<i class="quiz1-icon-incorrect" aria-hidden="true"></i>
+			<span class="feedback-text">{% trans "Incorrect" %}</span>
+		{% endif %}
+	</p>
+{% endif %}

--- a/access/types/forms.py
+++ b/access/types/forms.py
@@ -34,10 +34,10 @@ class GradedForm(forms.Form):
         if "exercise" not in kwargs:
             raise ConfigError("Missing exercise configuration from form arguments.")
         self.exercise = kwargs.pop("exercise")
-        self.show_correct = kwargs.pop('show_correct') if 'show_correct' in kwargs else False
-        self.show_correct_once = kwargs.pop('show_correct_once') if 'show_correct_once' in kwargs else False
+        self.model_answer = kwargs.pop('model_answer') if 'model_answer' in kwargs else False
+        self.reveal_correct = kwargs.pop('reveal_correct') if 'reveal_correct' in kwargs else False
         if not self.exercise.get('reveal_model_at_max_submissions', False):
-            self.show_correct_once = False
+            self.reveal_correct = False
         self.request = kwargs.pop('request') if 'request' in kwargs else None
         kwargs['label_suffix'] = ''
 
@@ -52,7 +52,7 @@ class GradedForm(forms.Form):
 
         self.form_id = "exercise-{}-form".format(random_id)
         self.form_nonce = random_id
-        self.disabled = self.show_correct
+        self.disabled = self.model_answer
         self.randomized = False
         self.rng = random.Random()
         self.multipart = False
@@ -199,7 +199,7 @@ class GradedForm(forms.Form):
         choices, initial, correct = self.create_choices(config)
         for row in config.get('rows', []):
 
-            if self.show_correct:
+            if self.model_answer:
                 correct = []
                 corr = self.row_options(config, row)['options']
                 for i,choice in enumerate(choices):
@@ -252,7 +252,7 @@ class GradedForm(forms.Form):
                 )
             args['choices'] = selected_choices
 
-        if self.show_correct:
+        if self.model_answer:
             if correct:
                 args['initial'] = correct_choices if multiple else correct_choices[0]
             elif config.get('model', False):
@@ -281,7 +281,7 @@ class GradedForm(forms.Form):
         else:
             field.random_sample = ''
 
-        if self.show_correct_once:
+        if self.reveal_correct:
             if correct:
                 field.correct = correct
             elif config.get('model', False):

--- a/access/types/forms.py
+++ b/access/types/forms.py
@@ -107,7 +107,7 @@ class GradedForm(forms.Form):
                 t = field["type"]
 
                 # Create a field by type.
-                choices, initial, correct = self.create_choices(field)
+                choices, initial, correct, neutral = self.create_choices(field)
                 if t == "checkbox":
                     if 'randomized' in field and args[0] is not None:
                         # grading a randomized question
@@ -115,15 +115,15 @@ class GradedForm(forms.Form):
 
                     i, f = self.add_field(i, field,
                         forms.MultipleChoiceField, forms.CheckboxSelectMultiple,
-                        initial, correct, choices, True, {}, args[0])
+                        initial, correct, neutral, choices, True, {}, args[0])
                 elif t == "radio":
                     i, f = self.add_field(i, field,
                         forms.ChoiceField, forms.RadioSelect,
-                        initial, correct, choices, False, {})
+                        initial, correct, neutral, choices, False, {})
                 elif (t == "dropdown" or t == "select"):
                     i, f = self.add_field(i, field,
                         forms.ChoiceField, forms.Select,
-                        initial, correct, choices, False)
+                        initial, correct, neutral, choices, False)
                 elif t == "text":
                     i, f = self.add_field(i, field,
                         self._get_text_field_type(field), forms.TextInput)
@@ -196,7 +196,7 @@ class GradedForm(forms.Form):
 
     def add_table_fields(self, i, config, field_class, widget_class, multiple=False):
         fields = []
-        choices, initial, correct = self.create_choices(config)
+        choices, initial, correct, neutral = self.create_choices(config)
         for row in config.get('rows', []):
 
             if self.model_answer:
@@ -229,7 +229,7 @@ class GradedForm(forms.Form):
         return i, fields
 
     def add_field(self, i, config, field_class, widget_class,
-            initial=None, correct=None, choices=None, multiple=False,
+            initial=None, correct=None, neutral=None, choices=None, multiple=False,
             widget_attrs={'class': 'form-control'}, post_data=None):
         args = {
             'widget': widget_class(attrs=widget_attrs),
@@ -241,6 +241,7 @@ class GradedForm(forms.Form):
         name = self.field_name(i, config)
         selected_choices = choices
         correct_choices = correct
+        neutral_choices = neutral
         initial_choices = initial
         random_attributes = None
 
@@ -253,7 +254,11 @@ class GradedForm(forms.Form):
             args['choices'] = selected_choices
 
         if self.model_answer:
-            if correct:
+            # Checks the correct fields in a model answer
+            if neutral_choices and correct_choices:
+                combined = correct_choices + neutral_choices
+                args['initial'] = combined
+            elif correct_choices:
                 args['initial'] = correct_choices if multiple else correct_choices[0]
             elif config.get('model', False):
                 args['initial'] = config['model']
@@ -273,6 +278,14 @@ class GradedForm(forms.Form):
         field.more = self.create_more(config)
         field.points = config.get('points', 0)
         field.choice_list = choices is not None and widget_class != forms.Select
+        field.neutral = neutral
+
+        if correct:
+            field.correct = correct
+        elif config.get('model', False):
+            field.correct = config['model']
+        elif config.get('correct', False):
+            field.correct = config['correct']
 
         if random_attributes:
             field.randomized = True
@@ -280,22 +293,6 @@ class GradedForm(forms.Form):
             field.random_checksum = random_attributes['checksum']
         else:
             field.random_sample = ''
-
-        if self.reveal_correct:
-            if correct:
-                field.correct = correct
-            elif config.get('model', False):
-                field.correct = config['model']
-            elif config.get('correct', False):
-                field.correct = config['correct']
-            if 'options' in config:
-                neutral = []
-                a = 0
-                for opt in config['options']:
-                    if opt.get('correct') == 'neutral':
-                        neutral.append(self.option_name(a, opt))
-                    a += 1
-                field.neutral = neutral
 
         if 'extra_info' in config and 'class' in config['extra_info']:
             field.html_class = config['extra_info']['class']
@@ -318,26 +315,28 @@ class GradedForm(forms.Form):
 
     def create_choices(self, configuration):
         '''
-        Creates field choices by configuration.
-
+        Creates choices for dropdown, select, radio and checkbox-type questions.
+        Create also the lists of correct, neutral and initially selected options.
         '''
         choices = []
         initial = []
         correct = []
+        neutral = []
         if "options" in configuration:
             i = 0
             for opt in configuration["options"]:
                 label = opt.get('label', "")
                 value = self.option_name(i, opt)
                 choices.append((value, mark_safe(label)))
-                if opt.get('correct', False) is True:
-                    # Not always boolean; string "neutral" is a possible value.
+                if opt.get('correct') == "neutral":
+                    neutral.append(value)
+                elif opt.get('correct', False) is True:
                     correct.append(value)
                 if opt.get('selected', False) or opt.get('initial', False):
                     initial.append(value)
                 i += 1
 
-        return choices, initial, correct
+        return choices, initial, correct, neutral
 
     def group_name(self, i):
         return "group_{:d}".format(i)

--- a/access/types/forms.py
+++ b/access/types/forms.py
@@ -34,8 +34,8 @@ class GradedForm(forms.Form):
         if "exercise" not in kwargs:
             raise ConfigError("Missing exercise configuration from form arguments.")
         self.exercise = kwargs.pop("exercise")
-        self.model_answer = kwargs.pop('model_answer') if 'model_answer' in kwargs else False
-        self.reveal_correct = kwargs.pop('reveal_correct') if 'reveal_correct' in kwargs else False
+        self.model_answer = kwargs.pop('model_answer', False)
+        self.reveal_correct = kwargs.pop('reveal_correct', False)
         if not self.exercise.get('reveal_model_at_max_submissions', False):
             self.reveal_correct = False
         self.request = kwargs.pop('request') if 'request' in kwargs else None

--- a/access/types/stdsync.py
+++ b/access/types/stdsync.py
@@ -154,9 +154,14 @@ def createFormModel(request, course, exercise, parameter):
     form = GradedForm(None, exercise=exercise, model_answer=True)
     form.bind_initial()
     points,error_groups,error_fields = form.grade()
-    result = { "form": form, "accepted": True, "points": points,
-        "error_groups": error_groups, "error_fields": error_fields,
-        "model_answer": True }
+    result = {
+        "form": form,
+        "accepted": True,
+        "points": points,
+        "error_groups": error_groups,
+        "error_fields": error_fields,
+        "model_answer": True,
+    }
     return render_template(request, course, exercise, None,
         'access/graded_form.html', result)
 

--- a/access/types/stdsync.py
+++ b/access/types/stdsync.py
@@ -108,7 +108,7 @@ def createForm(request, course, exercise, post_url):
 
     try:
         form = GradedForm(request.POST or None, request.FILES or None,
-            exercise=exercise, show_correct_once=last, request=request)
+            exercise=exercise, reveal_correct=last, request=request)
     except PermissionDenied:
         # Randomized forms raise PermissionDenied when the POST data contains
         # forged checksums or samples. It could be cleaner to check those
@@ -151,11 +151,12 @@ def createForm(request, course, exercise, post_url):
 
 
 def createFormModel(request, course, exercise, parameter):
-    form = GradedForm(None, exercise=exercise, show_correct=True)
+    form = GradedForm(None, exercise=exercise, model_answer=True)
     form.bind_initial()
     points,error_groups,error_fields = form.grade()
     result = { "form": form, "accepted": True, "points": points,
-        "error_groups": error_groups, "error_fields": error_fields }
+        "error_groups": error_groups, "error_fields": error_fields,
+        "model_answer": True }
     return render_template(request, course, exercise, None,
         'access/graded_form.html', result)
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -43,7 +43,7 @@ msgstr ""
 #: access/templates/access/accept_general_form.html:42
 #: access/templates/access/accept_git_form.html:16
 #: access/templates/access/accept_post_form.html:17
-#: access/templates/access/graded_form.html:197
+#: access/templates/access/graded_form.html:201
 msgid "Submit"
 msgstr "Lähetä"
 
@@ -286,7 +286,7 @@ msgstr ""
 "    "
 
 #: access/templates/access/graded_form.html:49
-#: access/templates/access/graded_form_feedback.html:20
+#: access/templates/access/graded_form_feedback.html:39
 msgid "Incorrect"
 msgstr "Vastauksesi on väärin."
 
@@ -311,21 +311,25 @@ msgstr[1] ""
 "\n"
 "%(points)s pistettä"
 
-#: access/templates/access/graded_form_feedback.html:15
+#: access/templates/access/graded_form.html:134
+msgid "neutral option which does not affect grading"
+msgstr "neutraali vaihtoehto, joka ei vaikuta kokonaispisteisiin"
+
+#: access/templates/access/graded_form_feedback.html:9
+#: access/templates/access/graded_form_feedback.html:36
 msgid "Correct!"
 msgstr "Oikein!"
 
-#: access/templates/access/graded_form_feedback.html:25
+#: access/templates/access/graded_form_feedback.html:14
 msgid "Incorrect. You can check the correct options above."
 msgstr "Vastauksesi on väärin. Yllä näet oikeat vastaukset."
 
-#: access/templates/access/graded_form_feedback.html:27
+#: access/templates/access/graded_form_feedback.html:16
 msgid ""
 "Neutral options which do not affect grading are marked with a question mark."
-msgstr ""
-"Kysymysmerkillä varustetut vaihtoehdot eivät vaikuta kokonaispisteisiin."
+msgstr "Kysymysmerkillä merkityt vaihtoehdot eivät vaikuta kokonaispisteisiin."
 
-#: access/templates/access/graded_form_feedback.html:30
+#: access/templates/access/graded_form_feedback.html:19
 msgid "Incorrect. The correct answer is"
 msgstr "Vastauksesi on väärin. Oikea vastaus on"
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/apluslms/mooc-grader/issues/55 

Neutral options of checkbox-type questions have been added to the model answer in questionnaire. Previously they only showed briefly at the moment when the student reached maximum amount of submissions if the “reveal-model-at-max-submissions" was set to true. 

At the same time, the role of these two different model answers have been cleared up a bit and pushed towards the other [general exercise configuration](https://github.com/apluslms/mooc-grader/tree/master/courses#accesstypesstdsynccreateform), by renaming the form attributes for the model answers.

The only visible change to appearance, is the indication of neutral answers and hiding the option-related hints, when checking the model answer:

![image](https://user-images.githubusercontent.com/43036333/89891647-1e8cfb80-dbde-11ea-93ad-4ea1a473f2ef.png)

# Testing 

Has been tested with: 

1. Normal checkboxes without neutral option(s) 
2. Normal checkboxes with neutral option(s) 
3. Randomized checkboxes with neutral option(s) 
4. Randomized checkboxes without neutral option(s) 
5. Questionnaires with other types of questions at the same time as checkbox-questions (radio-, text- and dropdown-fields)
6. All the above, while there are general and option-related hints available 

Existing automatic tests also pass.

# Have you updated the README or other relevant documentation?

Not really relevant

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
