### PR TITLE
Disable points and feedback from enrollment questionnaire

### DIFF
--- a/access/templates/access/graded_form.html
+++ b/access/templates/access/graded_form.html
@@ -37,7 +37,7 @@
 			{% endif %}
 
 			{% if not field.field.group_errors %}
-			{% if result.accepted %}
+			{% if result.accepted and not result.form.enrollment_exercise %}
 			<!-- Points badge -->
 				{% if not exercise.feedback or field.field.points > 0 %}
 				<span class="badge badge-{% if field.field.grade_points > 0 and field.field.grade_points < field.field.max_points %}warning{% elif field.field.name in result.error_fields %}danger{% else %}success{% endif %}">
@@ -165,7 +165,7 @@
 			<!-- End of a text-field -->
 			{% endif %}
 
-		{% if result.accepted and not result.model_answer and not field.field.row_label or field.field.close_table %}
+		{% if result.accepted and not result.form.enrollment_exercise and not result.model_answer and not field.field.row_label or field.field.close_table %}
 			<!-- Question feedback -->
 			<div>
 				{% if field.field.type == "checkbox" %}

--- a/access/types/forms.py
+++ b/access/types/forms.py
@@ -56,6 +56,7 @@ class GradedForm(forms.Form):
         self.randomized = False
         self.rng = random.Random()
         self.multipart = False
+        self.enrollment_exercise = self.is_enrollment_exercise()
         samples = []
         g = 0
         i = 0


### PR DESCRIPTION
The status-text "Correct!" and the points badges (0/0 for all questions, regardless of the answer) were shown for enrollment questionnaires too. This removes them as unnecessary feedback. The green alert of "you got 0/0 points for this questionnaire" was already removed in an earlier pull request. 

**Before changes** 

![Screenshot from 2020-08-19 09-07-34](https://user-images.githubusercontent.com/43036333/90598755-51497c00-e1fc-11ea-98ec-b7c9b4fe6aea.png)


**After changes** 

![image](https://user-images.githubusercontent.com/43036333/90513966-2feb8000-e169-11ea-81f6-5520845b5bd6.png) 

If there is an required answer missing from the questionnaire, that is displayed now also better due to the earlier pull requests:

![image](https://user-images.githubusercontent.com/43036333/90599338-578c2800-e1fd-11ea-967b-bfd8969f0062.png)


![image](https://user-images.githubusercontent.com/43036333/90599320-4cd19300-e1fd-11ea-9c9b-37ce7eab4a7f.png)


# Have you updated the README or other relevant documentation? 

Doesn't require updates. 

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)? 

- [ ] I (developer) have created unit tests and the tests pass 
- [ ] I (developer) have created functional tests (Selenium tests) if applicable 
- [x] I (developer) have tested the changes manually 
- [ ] Reviewer has finished the code review 
- [ ] After the review, the developer has made changes accordingly 
- [ ] Customer/Teacher has accepted the implementation of the feature 