### PR TITLE
Change style of list-items in error summary

### DIFF
--- a/access/templates/access/_error_summary.html
+++ b/access/templates/access/_error_summary.html
@@ -5,14 +5,17 @@
 	<div class="error-summary__text">
 		<h4>{% trans "Submission failed" %}</h4>
 		<p>{% trans "Check your answers before trying again:" %}</p>
+		<ul>
 		{% for field in result.form %}
 			{% if field.errors %}
-				<p>{{ field.label }}:
-				{% for error in field.errors %}
-					{{ error }}
-				{% endfor %}
-				</p>
+				<li>
+					<strong>{{ field.label }}: </strong>
+					{% for error in field.errors %}
+						{{ error }}
+					{% endfor %}
+				</li>		
 			{% endif %}
 		{% endfor %}
+		</ul>
 	</div>
 </div>


### PR DESCRIPTION
Changes the style of the items in the error summary,
adds emphasis on the field label, and presents the errors
as ul-element, instead of individual p-elements.

Related to the changes: https://github.com/apluslms/a-plus/pull/658
And in: https://github.com/apluslms/a-plus-design-system/pull/9

# Testing

Testing of the outlook has been done in: https://github.com/apluslms/a-plus/pull/658

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
