### PR TITLE
Update format of container options given to the creation script & update docs

### DIFF
--- a/access/types/stdasync.py
+++ b/access/types/stdasync.py
@@ -310,8 +310,7 @@ def _acceptSubmission(request, course, exercise, post_url, sdir):
     exercise_extra = {
         "key": exercise["key"],
         "title": exercise.get("title", None),
-        "resources": c.get("resources", {}), # Unofficial param, implemented differently later
-        "require_constant_environment": c.get("require_constant_environment", False) # Unofficial param, implemented differently later
+        "container_config": c
     }
     if exercise.get("personalized", False):
         exercise_extra["personalized_exercise"] \

--- a/courses/README.md
+++ b/courses/README.md
@@ -184,7 +184,19 @@ course specific exercise view in a course specific Python module.
 		asynchronous submissions (normally occurs if queue is shorter than 3)
 	* `feedback_template` (default `access/task_success.html`):
 		name of a template used to format the feedback
-	* `actions`: list of asynchronous test actions
+	* `container`: A dictionary for configuring attributes of the grading container
+		* `image`: Container image to use
+		* `mount`: Directory to mount to the container
+		* `cmd`: Command to execute inside the grading container - typically along the lines of `/exercise/run.sh`
+
+	Additional fields can be defined in the `container` dictionary, and they're given to the **site-specific** container creation script. **Aalto's installation** currently accepts the following fields:
+
+	*   * `resources` (optional): A dictionary defining resource limits for the container, with the following keys:
+			* `cpu` (optional, default `2`): Number of CPU cores to allocate
+			* `memory` (optional, default `4Gi`): Amount of memory to allocate
+		* `enable_network` (optional, default `False`): Whether the container should have generic network access
+		* `require_constant_environment` (optional, default `False`): Generally used for timed exercises where the number of points received depends on code execution time. Setting this to `True` causes the containers to end up in an environment where only one submission is run at a time, and all the grading nodes have identical hardware, so the variance in execution times should be minimal.
+		* `privileged` (optional, default `False`): Setting this to `True` essentially grants root access to the grading node where the container is run. This can be needed e.g. in exercises requiring access to `/dev/kvm` or docker-in-docker exercises. Privileged submissions are run on a separate node entirely dedicated to them. This should generally be used as a **last resort**, and the exercise creator should make sure that student code cannot escape the container.
 
 2. ### access.types.stdasync.acceptPost
 	Accepts form text for asynchronous grading queue. Extended attributes:


### PR DESCRIPTION
# Description

Update the way the container options are given to the k8s script - now all `container` fields are given, which allows adding / changing the k8s environment options more freely with less hassle. Also updated exercise documentation, replacing the deprecated `actions` field with the more up-to-date `container` field and its options.

# Testing

Manually tested. Updated k8s-run script on minus.cs.

# Have you updated the README or other relevant documentation?

Yep.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
