### PR TITLE
Remove personal directory feature from personalised exercises

### DIFF
--- a/access/types/stdasync.py
+++ b/access/types/stdasync.py
@@ -31,8 +31,7 @@ from django.utils import translation
 from util.files import create_submission_dir, save_submitted_file, \
     clean_submission_dir, write_submission_file, write_submission_meta
 from util.http import not_modified_since, not_modified_response, cache_headers
-from util.personalized import select_generated_exercise_instance, \
-    user_personal_directory_path
+from util.personalized import select_generated_exercise_instance
 from util.shell import invoke
 from util.templates import render_configured_template, render_template, \
     template_to_str

--- a/grader/settings.py
+++ b/grader/settings.py
@@ -152,14 +152,6 @@ SUBMISSION_PATH = join(BASE_DIR, 'uploads')
 # Django process requires write access to this directory.
 PERSONALIZED_CONTENT_PATH = join(BASE_DIR, 'exercises-meta')
 
-# Enable personal directories for users, which can be used in personalized
-# exercises to permanently store personal files with the
-# grader.actions.store_user_files action. Personalized exercises can still be
-# used even if this setting is False if the grading only uses the pregenerated
-# exercise instance files. Enabling and using personal directories makes the
-# grader stateful, which at least increases the amount of disk space used.
-ENABLE_PERSONAL_DIRECTORIES = False
-
 # Logging
 # https://docs.djangoproject.com/en/1.7/topics/logging/
 ##########################################################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Django==1.9.7
 raphendyr-django-essentials==1.3.0
-celery==3.1.23
 requests==2.10.0
 PyYAML==3.11
 docutils==0.12


### PR DESCRIPTION
# Description

As mentioned in #58 the personal directory is not longer used.

Fixes #89
# Testing

I tested the personalised exercises of the Aplus manual and they worked as expected.

# Have you updated the README or other relevant documentation?

...

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [X] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
