### PR TITLE
Non sudo gitmanager cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,6 @@ Django must install the database schema for the `gitmanager` (Python virtual env
 
     python manage.py migrate
 
-The `gitmanager` requires a crontab for the root account:
+The `gitmanager` requires a crontab for the grader account:
 
-    sudo crontab -u root doc/gitmanager-root-crontab
+    sudo crontab -u grader doc/gitmanager-crontab

--- a/doc/gitmanager-crontab
+++ b/doc/gitmanager-crontab
@@ -1,7 +1,7 @@
 # crontab for mooc-grader gitmanager
 # Required for automatic course content updates via git
-# Must be run as root (because it updates the chroot sandbox)
-# Install: $ sudo crontab -u root this_file
+# Should be run as the user owning the course directories, typically 'grader'
+# Install: $ sudo crontab -u grader this_file
 
 * * * * * /srv/grader/mooc-grader/gitmanager/cron.sh
 

--- a/gitmanager/cron.sh
+++ b/gitmanager/cron.sh
@@ -43,7 +43,7 @@ while read key; do
   # reset/start log
   echo "Updating '$key' (update_id=$update_id, request_time=$request_time)" > "$LOG"
 
-  sudo -u $USER -H gitmanager/cron_pull_build.sh "$TRY_PYTHON" "$key" "$url" "$branch" >> "$LOG" 2>&1 || continue
+  gitmanager/cron_pull_build.sh "$TRY_PYTHON" "$key" "$url" "$branch" >> "$LOG" 2>&1 || continue
 
   # Update database
   $SQL >/dev/null <<SQL


### PR DESCRIPTION
# Description

**What?**

Removed a sudo call from gitmanager's `cron.sh` script and updated the documentation accordingly.

**Why?**

The sudo call is not required in the current non-chroot-sandbox deployment, and was additionally interfering with running gitmanager in a production container.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested running `cron.sh` as the `grader` user on the minus.cs test server.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [x] This pull request cannot be tested in the browser.

# Have you updated the README or other relevant documentation?

- [x] documents inside the doc directory.
- [x] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature