### PR TITLE
Conditionally disable loading settings from environment variables

### DIFF
--- a/grader/settings.py
+++ b/grader/settings.py
@@ -200,8 +200,13 @@ update_settings_with_file(__name__,
                           environ.get('GRADER_LOCAL_SETTINGS', 'local_settings'),
                           quiet='GRADER_LOCAL_SETTINGS' in environ)
 update_settings_from_module(__name__, 'settings_local', quiet=True) # Compatibility with older releases
-update_settings_from_environment(__name__, 'DJANGO_') # FIXME: deprecated
-update_settings_from_environment(__name__, 'GRADER_')
+
+# If 'DISABLE_LOAD_ENVIRONMENT_SETTINGS' is found in env vars, don't load DJANGO_ and GRADER_ prefixed settings
+load_environment_settings = not 'DISABLE_LOAD_ENVIRONMENT_SETTINGS' in environ
+if load_environment_settings:
+    update_settings_from_environment(__name__, 'DJANGO_') # FIXME: deprecated
+    update_settings_from_environment(__name__, 'GRADER_')
+
 update_secret_from_file(__name__, environ.get('GRADER_SECRET_KEY_FILE', 'secret_key'))
 update_secret_from_file(__name__, environ.get('GRADER_AJAX_KEY_FILE', 'ajax_key'), setting='AJAX_KEY')
 assert AJAX_KEY, "Secure random string is required in AJAX_KEY"


### PR DESCRIPTION
# Description

Added an environmental-variable enabled option to disable parsing environment variables starting with `GRADER_` or `DJANGO_` as settings.

**Why?**

The old non-checking version could accidentally parse undesired environment variables as settings. These variables could be set e.g. by Kubernetes, if pods / service names started with `grader`, and there was no way of overriding in local_settings.py, as the code is executed in settings.py in any case.

This was especially meaningful in gitmanager's functionality, as some of the variables set couldn't be parsed in JSON, throwing errors. When running gitmanager's read_static_dir command, the errors would be appended to the directory name output by the command, garbling the actual result.

**How?**

Setting the DISABLE_LOAD_ENVIRONMENT_SETTINGS environment variable now causes the wildcard environment variable setting loadings to longer to happen.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [x] This pull request cannot be tested in the browser.

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature