### PR TITLE
Change environment variable setting loading schema

### DIFF
--- a/grader/settings.py
+++ b/grader/settings.py
@@ -201,11 +201,9 @@ update_settings_with_file(__name__,
                           quiet='GRADER_LOCAL_SETTINGS' in environ)
 update_settings_from_module(__name__, 'settings_local', quiet=True) # Compatibility with older releases
 
-# If 'DISABLE_LOAD_ENVIRONMENT_SETTINGS' is found in env vars, don't load DJANGO_ and GRADER_ prefixed settings
-load_environment_settings = not 'DISABLE_LOAD_ENVIRONMENT_SETTINGS' in environ
-if load_environment_settings:
-    update_settings_from_environment(__name__, 'DJANGO_') # FIXME: deprecated
-    update_settings_from_environment(__name__, 'GRADER_')
+# Load settings from environment variables starting with ENV_SETTINGS_PREFIX (default GRADER_)
+ENV_SETTINGS_PREFIX = environ.get('ENV_SETTINGS_PREFIX', 'GRADER_')
+update_settings_from_environment(__name__, ENV_SETTINGS_PREFIX)
 
 update_secret_from_file(__name__, environ.get('GRADER_SECRET_KEY_FILE', 'secret_key'))
 update_secret_from_file(__name__, environ.get('GRADER_AJAX_KEY_FILE', 'ajax_key'), setting='AJAX_KEY')


### PR DESCRIPTION
# Description

**What?**

Change the recently-changed environment variable based settings loading again to not binarily enable or disable loading settings from environment variables, but instead define custom prefix to load settings from.

**Why?**

Loading environment variables can still prove useful as long as it's done in a controlled manner.

**How?**

Load prefix from ENV_SETTINGS_PREFIX, then load settings from env variables with said prefix.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.