### PR TITLE
Update aplus-auth to 0.2.0, add permission checks to views, add logging, fix custom template caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+courses/
+course_store/

--- a/access/converters.py
+++ b/access/converters.py
@@ -1,0 +1,8 @@
+class BasenameConverter:
+    regex="[\w\d\_\-\.]*"
+
+    def to_python(self, value: str) -> str:
+        return value
+
+    def to_url(self, value: str) -> str:
+        return value

--- a/access/urls.py
+++ b/access/urls.py
@@ -1,19 +1,33 @@
-from django.conf.urls import url
+from django.urls import path, register_converter
 
 from access import views
+from access.converters import BasenameConverter
+
+register_converter(BasenameConverter, "basename")
 
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
-    url(r'^configure$', views.configure, name='configure'),
-    url(r'^test-result$', views.test_result, name='test-result'),
-    url(r'^container-post$', views.container_post, name='container-post'),
-    url(r'^ajax/([\w-]+)/([\w-]+)$', views.exercise_ajax, name='ajax'),
-    url(r'^model/([\w-]+)/([\w-]+)/([\w\d\_\-\.]*)$', views.exercise_model, name='model'),
-    url(r'^exercise_template/([\w-]+)/([\w-]+)/([\w\d\_\-\.]*)$', views.exercise_template, name='exercise_template'),
-    url(r'^generatedfile/([\w-]+)/([\w-]+)/(\d+)/([\w-]+(?:\.\w+)?)$', views.generated_exercise_file,
-        name='generated-file'),
-    url(r'^([\w-]+)/$', views.course, name='course'),
-    url(r'^([\w-]+)/aplus-json$', views.aplus_json, name='aplus-json'),
-    url(r'^([\d-]+|[\w-]+)/([\w-]+)$', views.exercise, name='exercise'),
-    url(r'^login$', views.LoginView.as_view(), name="login"),
+    path("", views.index, name='index'),
+    path("configure", views.configure, name='configure'),
+    path("test-result", views.test_result, name='test-result'),
+    path("container-post", views.container_post, name='container-post'),
+    path("ajax/<slug:course_key>/<slug:exercise_key>", views.exercise_ajax, name='ajax'),
+    path(
+        "model/<slug:course_key>/<slug:exercise_key>/<basename:parameter>",
+        views.exercise_model,
+        name='model',
+    ),
+    path(
+        "exercise_template/<slug:course_key>/<slug:exercise_key>/<basename:parameter>",
+        views.exercise_template,
+        name='exercise_template',
+    ),
+    path(
+        "generatedfile/<slug:course_key>/<slug:exercise_key>/<int:exercise_instance>/<basename:filename>",
+        views.generated_exercise_file,
+        name='generated-file',
+    ),
+    path("<slug:course_key>/", views.course, name='course'),
+    path("<slug:course_key>/aplus-json", views.aplus_json, name='aplus-json'),
+    path("<slug:course_key>/<slug:exercise_key>", views.exercise, name='exercise'),
+    path("login", views.LoginView.as_view(), name="login"),
 ]

--- a/access/views.py
+++ b/access/views.py
@@ -8,7 +8,7 @@ from shutil import rmtree
 from tarfile import TarFile
 from typing import List
 
-from aplus_auth.payload import Permission
+from django.core.exceptions import PermissionDenied
 from django.shortcuts import render
 from django.http.response import HttpResponse, JsonResponse, Http404, HttpResponseForbidden
 from django.utils import timezone
@@ -27,7 +27,14 @@ from util.files import (
 )
 from util.http import post_data
 from util.importer import import_named
-from util.login_required import login_required
+from util.auth import (
+    access_read_check_if_number,
+    access_write_check,
+    access_write_check_if_number,
+    has_read_access,
+    instance_read_access_required,
+    login_required,
+)
 from util.monitored_dict import MonitoredDict
 from util.personalized import read_generated_exercise_file
 from util.templates import template_to_str
@@ -36,11 +43,13 @@ from util.templates import template_to_str
 LOGGER = logging.getLogger('main')
 
 
+@login_required
 def index(request):
     '''
     Signals that the grader is ready and lists available courses.
     '''
-    courses = config.courses()
+    courses = [course for course in config.courses() if has_read_access(request, course["key"])]
+
     if request.is_ajax():
         return JsonResponse({
             "ready": True,
@@ -63,8 +72,11 @@ def publish(request):
 
     course_id = request.POST["course_id"]
 
-    if not request.auth.permissions.instances.has(Permission.WRITE, id=int(course_id)):
-        return HttpResponse(status=401)
+    try:
+        access_write_check(request, course_id)
+    except ValueError as e:
+        LOGGER.info(f"Invalid course_id field: {e}")
+        return HttpResponse(f"Invalid course_id field: {e}", status=400)
 
     root_dir = Path(settings.COURSES_PATH)
     store_root_dir = Path(settings.COURSE_STORE)
@@ -123,16 +135,18 @@ def configure(request):
     if "exercises" not in request.POST or "course_id" not in request.POST:
         return HttpResponse("Missing exercises or course_id", status=400)
 
-    course_id = request.POST["course_id"]
     try:
         exercises = json.loads(request.POST["exercises"])
-        course_id_int = int(course_id)
     except (JSONDecodeError, ValueError) as e:
-        LOGGER.exception("Invalid exercises or course_id field")
-        return HttpResponse(f"Invalid exercises or course_id field: {e}", status=400)
+        LOGGER.info(f"Invalid exercises field: {e}")
+        return HttpResponse(f"Invalid exercises field: {e}", status=400)
 
-    if not request.auth.permissions.instances.has(Permission.WRITE, id=course_id_int):
-        return HttpResponse(status=401)
+    course_id = request.POST["course_id"]
+    try:
+        access_write_check(request, course_id)
+    except ValueError as e:
+        LOGGER.info(f"Invalid course_id field: {e}")
+        return HttpResponse(f"Invalid course_id field: {e}", status=400)
 
     root_dir = Path(settings.COURSE_STORE)
     course_path = root_dir / course_id
@@ -199,7 +213,7 @@ def configure(request):
     return JsonResponse(defaults)
 
 
-@login_required
+@instance_read_access_required
 def course(request, course_key):
     '''
     Signals that the course is ready to be graded and lists available exercises.
@@ -241,6 +255,11 @@ def exercise(request, course_key, exercise_key):
     '''
     Presents the exercise and accepts answers to it.
     '''
+    if request.method == "GET":
+        access_read_check_if_number(request, course_key)
+    else:
+        access_write_check_if_number(request, course_key)
+
     post_url = request.GET.get('post_url', None)
     lang = request.POST.get('__grader_lang', None) or request.GET.get('lang', None)
     course = exercise = None
@@ -285,7 +304,7 @@ def exercise_ajax(request, course_key, exercise_key):
     return response
 
 
-@login_required
+@instance_read_access_required
 def exercise_model(request, course_key, exercise_key, parameter=None):
     '''
     Presents a model answer for an exercise.
@@ -326,7 +345,7 @@ def exercise_model(request, course_key, exercise_key, parameter=None):
         raise Http404()
 
 
-@login_required
+@instance_read_access_required
 def exercise_template(request, course_key, exercise_key, parameter=None):
     '''
     Presents the exercise template.
@@ -367,7 +386,7 @@ def exercise_template(request, course_key, exercise_key, parameter=None):
         raise Http404()
 
 
-@login_required
+@instance_read_access_required
 def aplus_json(request, course_key):
     '''
     Delivers the configuration as JSON for A+.
@@ -378,6 +397,7 @@ def aplus_json(request, course_key):
         return _error_response(exc=e)
     if course is None:
         raise Http404()
+
     data = _copy_fields(course, [
         "archive_time",
         "assistants",

--- a/grader/settings.py
+++ b/grader/settings.py
@@ -18,16 +18,20 @@ ADMINS = (
 )
 #SERVER_EMAIL = 'root@'
 ALLOWED_HOSTS = ["*"]
-# Local nessaging library settings, see [aplus-auth](https://pypi.org/project/aplus-auth/) for explanations
+# Authentication and authorization library settings
+# see https://pypi.org/project/aplus-auth/ for explanations
 APLUS_AUTH_LOCAL = {
+    #"UID": "...", # set to "grader" below, can be changed
     "PRIVATE_KEY": None,
     "PUBLIC_KEY": None,
-    "REMOTE_AUTHENTICATOR_KEY": None,
+    "REMOTE_AUTHENTICATOR_UID": None, # The UID of the remote authenticator, e.g. "aplus"
+    "REMOTE_AUTHENTICATOR_KEY": None, # The public key of the remote authenticator
     "REMOTE_AUTHENTICATOR_URL": None, # probably "https://<A+ domain>/api/v2/get-token/"
-    #"TRUSTED_KEYS": [...],
+    #"UID_TO_KEY": {...}
+    #"TRUSTED_UIDS": [...],
     #"TRUSTING_REMOTES": [...],
-    #"DISABLE_LOGIN_CHECKS": False,
     #"DISABLE_JWT_SIGNING": False,
+    #"DISABLE_LOGIN_CHECKS": False,
 }
 
 # modify this if there are very large courses to be configured through /configure
@@ -40,6 +44,7 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 10*1024*1024 # 10MB
 
 # Messaging library
 APLUS_AUTH: Dict[str, Optional[str]] = {
+    "UID": "grader",
     "AUTH_CLASS": "access.auth.Authentication",
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ requests~=2.25.1
 PyYAML~=5.4.1
 docutils~=0.17.1
 python-magic~=0.4.22
-aplus-auth~=0.1.0
+aplus-auth~=0.2.0
 docker~=5.0.0

--- a/util/auth.py
+++ b/util/auth.py
@@ -1,0 +1,118 @@
+from functools import wraps
+from typing import Callable, Union
+
+from aplus_auth import settings as auth_settings
+from aplus_auth.auth.django import login_required as login_required_base
+from aplus_auth.payload import Permission
+from django.core.exceptions import PermissionDenied
+from django.http.response import HttpResponse
+
+ViewType = Callable[..., HttpResponse]
+login_required: Callable[[ViewType],ViewType] = login_required_base(redirect_url="/login?referer={url}")
+
+
+def access_check(request, permission: Permission, course_key: Union[str,int]):
+    """
+    Raises PermissionDenied if no <permission> access, and ValueError if
+    course_key couldn't be parsed as an integer.
+    """
+    if isinstance(course_key, str):
+        try:
+            course_key = int(course_key)
+        except ValueError:
+            raise ValueError("instance id is not an integer")
+
+    if auth_settings().DISABLE_LOGIN_CHECKS:
+        return True
+
+    if not hasattr(request, "auth") or request.auth is None:
+        return False
+
+    # if the key is self signed and the permissions are empty, we assume it is
+    # a 'master' key with access to everything
+    has_empty_perms = next(iter(request.auth.permissions), None) is None
+    if has_empty_perms and request.auth.iss == auth_settings().UID:
+        return True
+
+    if not request.auth.permissions.instances.has(permission, id=course_key):
+        raise PermissionDenied(f"No access to instance {course_key}")
+
+def access_read_check(request, course_key: Union[str,int]):
+    """
+    Raises PermissionDenied if no read access, and ValueError if
+    course_key couldn't be parsed as an integer.
+    """
+    access_check(request, Permission.READ, course_key)
+
+def access_write_check(request, course_key: Union[str,int]):
+    """
+    Raises PermissionDenied if no write access, and ValueError if
+    course_key couldn't be parsed as an integer.
+    """
+    access_check(request, Permission.WRITE, course_key)
+
+
+def access_check_if_number(request, permission: Permission, course_key: Union[str,int]):
+    """Checks access if course_key is a number, otherwise does nothing"""
+    try:
+        access_check(request, permission, course_key)
+    except ValueError:
+        # cant check permissions if course key isn't a number
+        pass
+
+def access_read_check_if_number(request, course_key: Union[str,int]):
+    """Checks read access if course_key is a number, otherwise does nothing"""
+    access_check_if_number(request, Permission.READ, course_key)
+
+def access_write_check_if_number(request, course_key: Union[str,int]):
+    """Checks write access if course_key is a number, otherwise does nothing"""
+    access_check_if_number(request, Permission.WRITE, course_key)
+
+
+def has_access(request, permission: Permission, course_key: Union[str,int], *, default: bool = True):
+    """Returns whether user has <permission> access to the course <course_key>"""
+    try:
+        access_check(request, permission, course_key)
+    except ValueError:
+        return default
+    except PermissionDenied:
+        return False
+
+    return True
+
+def has_read_access(request, course_key: Union[str,int], *, default: bool = True):
+    """Returns whether user has read access to the course <course_key>"""
+    return has_access(request, Permission.READ, course_key, default=default)
+
+def has_write_access(request, course_key: Union[str,int], *, default: bool = True):
+    """Returns whether user has write access to the course <course_key>"""
+    return has_access(request, Permission.WRITE, course_key, default=default)
+
+
+def _instance_access_required(permission: Permission, view_func):
+    @wraps(view_func)
+    @login_required
+    def wrapper(request, *args, course_key, **kwargs) -> HttpResponse:
+        access_check_if_number(request, permission, course_key)
+        return view_func(request, *args, course_key, **kwargs)
+
+    return wrapper
+
+def instance_read_access_required(view_func):
+    """
+    A decorator for a view function.
+
+    1. Checks that user is logged in.
+    2. checks read access if course_key is a number, otherwise does nothing.
+    """
+    return _instance_access_required(Permission.READ, view_func)
+
+
+def instance_write_access_required(view_func):
+    """
+    A decorator for a view function.
+
+    1. Checks that user is logged in.
+    2. checks write access if course_key is a number, otherwise does nothing.
+    """
+    return _instance_access_required(Permission.WRITE, view_func)

--- a/util/log.py
+++ b/util/log.py
@@ -1,0 +1,20 @@
+import logging
+
+
+security_logger = logging.getLogger("gitmanager.security")
+
+class SecurityLog:
+    @staticmethod
+    def _msg(request, action: str, status: str, msg: str) -> str:
+        ip = request.META.get("REMOTE_ADDR")
+        user = request.user if hasattr(request, "user") else None
+        auth = request.auth if hasattr(request, "auth") else None
+        return f"SECURITY {action} {status} {request.path} {ip} {user} {msg} {auth}"
+
+    @staticmethod
+    def reject(request, action, msg="", *args, **kwargs):
+        return security_logger.info(SecurityLog._msg(request, action, "REJECTED", msg), *args, **kwargs)
+
+    @staticmethod
+    def accept(request, action, msg="", *args, **kwargs):
+        return security_logger.info(SecurityLog._msg(request, action, "ACCEPTED", msg), *args, **kwargs)

--- a/util/login_required.py
+++ b/util/login_required.py
@@ -1,8 +1,0 @@
-from typing import Callable
-
-from aplus_auth.auth.django import login_required as login_required_base
-from django.http.response import HttpResponse
-
-
-ViewType = Callable[..., HttpResponse]
-login_required: Callable[[ViewType],ViewType] = login_required_base(redirect_url="/login?referer={url}")


### PR DESCRIPTION
# Description

**What?**

Update aplus-auth to 0.2.0, add permission checks to views, add logging, and fix custom template caching.

**Why?**

Shortens JWT lengths, and increases security.
Security logging was required.
Templates wouldn't be reloaded after they were changed.

**How?**

Respond with 403 if the course key is an integer (i.e. it is the remote id) and the user has no access.
Logging on endpoints where there could be an effect to the course.
Remove caching of courses' custom templates.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [X] This pull request cannot be tested in the browser.

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
