### PR TITLE
Fix lang/language field handling

### DIFF
--- a/access/config.py
+++ b/access/config.py
@@ -325,13 +325,16 @@ class ConfigParser:
         return course_root
 
 
-    def _default_lang(self, data):
-        l = data.get('language')
-        if type(l) == list:
-            data['lang'] = l[0]
-        elif l == str:
-            data['lang'] = l
-        return data.get('lang', DEFAULT_LANG)
+    def _default_lang(self, data: dict) -> str:
+        languages = data.get('language', data.get('lang'))
+        data['lang'] = languages
+
+        if isinstance(languages, list):
+            return languages[0]
+        elif isinstance(languages, str):
+            return languages
+        else:
+            return DEFAULT_LANG
 
 
     def _exercise_root(self, course_root, exercise_key):

--- a/access/views.py
+++ b/access/views.py
@@ -9,6 +9,7 @@ from tarfile import TarFile
 from typing import List
 
 from django.core.exceptions import PermissionDenied
+from django.http import HttpRequest
 from django.shortcuts import render
 from django.http.response import HttpResponse, JsonResponse, Http404, HttpResponseForbidden
 from django.utils import timezone
@@ -404,7 +405,7 @@ def exercise_template(request, course_key, exercise_key, parameter=None):
 
 
 @instance_read_access_required
-def aplus_json(request, course_key):
+def aplus_json(request: HttpRequest, course_key: str) -> JsonResponse:
     '''
     Delivers the configuration as JSON for A+.
     '''
@@ -440,8 +441,6 @@ def aplus_json(request, course_key):
         "start",
         "view_content_to",
     ])
-    if "language" in course:
-        data["lang"] = course["language"]
 
     errors = []
 


### PR DESCRIPTION
# Description

**What?**

Allow the language(s) to be specified in either lang or language fields. There was also a bug if the 'language' contains a string but the DEFAULT_LANG has probably masked that in the past.

**Why?**

The field name was changed in a-plus-rst-tools to match the field name in A+.

**How?**

Check both language and lang for if the field is a list of languages. Also, saves the language list in the 'lang' field instead of just the default language, so the hack can be removed from aplus-json. The 'lang' field of the course entry doesn't seem to be used anywhere anyway (course root 'lang' is used though).

Fixes #132

# Testing
**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Checked that O1 course loads properly. It is technically possible that this breaks something if I missed any 'lang' field usages but I'm pretty sure I didn't. It also would only break it in the local testing environment as the languages aren't used with Git Manager.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [X] This pull request cannot be tested in the browser.

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [X] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
