### PR TITLE
Enable LTI parameters for grading

### DIFF
--- a/access/types/stdasync.py
+++ b/access/types/stdasync.py
@@ -22,6 +22,7 @@ Functions take arguments:
 import logging
 import copy
 import os
+import json
 from django.conf import settings
 from django.urls import reverse
 from django.core.exceptions import PermissionDenied
@@ -297,6 +298,21 @@ def _acceptSubmission(request, course, exercise, post_url, sdir: SubmissionDir):
     '''
     uids = get_uid(request)
     attempt = int(request.GET.get("ordinal_number", 1))
+
+    # Write LTI parameters for use in grading.
+    # The request is already authenticated and LTI signature is ignored.
+    if "lti" in exercise:
+        sdir.write_file("lti.json", json.dumps({
+            k: request.POST.get(k)
+            for k in (
+                "user_id",
+                "custom_student_id",
+                "lis_person_name_full",
+                "lis_person_name_given",
+                "lis_person_name_family",
+                "lis_person_contact_email_primary",
+            )
+        }))
 
     if "submission_url" in request.GET:
         surl = request.GET["submission_url"]

--- a/courses/README.md
+++ b/courses/README.md
@@ -188,6 +188,9 @@ course specific exercise view in a course specific Python module.
 		asynchronous submissions (normally occurs if queue is shorter than 3)
 	* `feedback_template` (default `access/task_success.html`):
 		name of a template used to format the feedback
+	* `lti` (optional with `lti_context_id`, `lti_resource_link_id`, `lti_aplus_get_and_post=True`):
+		A name for a configured LTI service for the mooc-grader at A-plus, the exercise receives
+		LTI user attributes from A-plus which are written to `lti.json` for the container.
 	* `container`: A dictionary for configuring attributes of the grading container
 		* `image`: Container image to use
 		* `mount`: Directory to mount to the container

--- a/util/export.py
+++ b/util/export.py
@@ -63,6 +63,17 @@ def exercise(request, course, exercise_root, of):
     else:
         of['url'] = url_to_exercise(request, course['key'], exercise['key'])
 
+    if 'lti' in exercise:
+        for k in (
+            'lti',
+            'lti_context_id',
+            'lti_resource_link_id',
+            'lti_aplus_get_and_post',
+            'lti_open_in_iframe',
+        ):
+            if k in exercise:
+                of[k] = exercise[k]
+
     form, i18n = form_fields(languages, exercises)
     of['exercise_info'] = {
         'form_spec': form,


### PR DESCRIPTION
# Description

**What?**

Enables LTI user attributes (real student id and name) for a selected mooc-grader execise if the mooc-grader server has an LTI configuration at A-plus.

**Why?**

A use case in "Applications for computing" and "Mechatronic Machine Design" requires to check a certificate from Matlab onramp with students real name. They hope to use this starting from January and using existing support in A-plus is the only way I can see it done in this timeframe.

**How?**

1. Supports LTI configuration in mooc-grader exercise which is handled in the A-plus "fetch settings" (as previously used for Rubyric exercises). If a matching LTI-service for the mooc-grader server is configured in the A-plus it will append LTI user attributes for requests to that specific mooc-grader exercise. No code changes in the A-plus are required.
2. The LTI configured mooc-grader exercise will record received user attributes to `lti.json` for use in the grading container.

# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

1. The LTI configuration is passed to the configuration JSON and processed by A-plus.
2. The LTI request parameters from A-plus are received and stored for grading.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

The changes do not change existing functionality or UI. Missing values are handled without errors.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [x] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [x] Other documentation (mention below which documentation).

courses/README.md about exercise configuration

# Considerations

When the A-plus LTI configuration for the mooc-grader server is added, it allows any exercises on that server to request LTI parameters. Perhaps the LTI configuration at A-plus could be limited to selected courses or exercises – I could look into that separately if you believe this could be acceptable by January.

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
