### PR TITLE
Remove and clean up old queue and wait variables

### DIFF
--- a/access/templates/access/async_accepted.html
+++ b/access/templates/access/async_accepted.html
@@ -2,17 +2,7 @@
 {% load i18n %}
 
 {% block exercise %}
-{% if result.synchronous %}
-<div class="alert alert-danger">
-	{% blocktrans trimmed %}
-		WARNING_GRADING_WAS_SYNCHRONOUS
-	{% endblocktrans %}
-</div>
-<div id="feedback">
-	{{ result.feedback }}
-</div>
-
-{% elif result.error %}
+{% if result.error %}
 <div class="alert alert-danger">
 	<h1>{% trans "SUBMISSION_FAILED" %}</h1>
 	<p>
@@ -38,13 +28,9 @@
 	<p>
 		{% if exercise.accepted_message %}
 			{{ exercise.accepted_message|safe }}
-		{% elif result.queue < 3 %}
+		{% else %}
 			{% blocktrans trimmed %}
 				SUBMISSION_IN_GRADING_NOW
-			{% endblocktrans %}
-		{% else %}
-			{% blocktrans trimmed with queue=result.queue %}
-				SUBMISSION_IN_GRADING_QUEUE -- {{ queue }}
 			{% endblocktrans %}
 		{% endif %}
 	</p>

--- a/access/templates/access/exercise_head.html
+++ b/access/templates/access/exercise_head.html
@@ -15,8 +15,8 @@
 		<meta name="status" value="rejected" />
 		{% elif result.accepted %}
 		<meta name="status" value="accepted" />
-		{% if result.wait and result.queue < 3 and not exercise.never_wait %}
-		<meta name="wait" value="{{ result.queue }}" />
+		{% if not exercise.never_wait %}
+		<meta name="wait" value="1" />
 		{% endif %}
 		{% endif %}
 

--- a/access/types/stdasync.py
+++ b/access/types/stdasync.py
@@ -370,13 +370,10 @@ def _acceptSubmission(request, course, exercise, post_url, sdir: SubmissionDir):
         settings=settings.RUNNER_MODULE_SETTINGS,
     )
     LOGGER.debug(f"Container order exit={return_code} out={out} err={err}")
-    qlen = 1
 
     return render_template(request, course, exercise, post_url,
         "access/async_accepted.html", {
             "error": return_code != 0,
             "accepted": True,
-            "wait": True,
             "missing_url": surl_missing,
-            "queue": qlen
         })

--- a/courses/README.md
+++ b/courses/README.md
@@ -355,7 +355,6 @@ listed below.
 		* `missing_files`: True if files missing
 		* `invalid_address`: True if Gitlab address is rejected
 		* `accepted`: True if accepted for grading
-		* `wait`: True if the grading should be finished in a moment
 	A default file submission form can be included with
 
 		{% include 'access/accept_files_form.html' %}

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MOOC-grader\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-23 10:21+0000\n"
+"POT-Creation-Date: 2023-06-05 13:16+0000\n"
 "PO-Revision-Date: 2021-08-23 13:54+0000\n"
 "Last-Translator: Ella Anttila <ella.anttila@aalto.fi>\n"
 "Language-Team: English <>\n"
@@ -94,12 +94,6 @@ msgid "POINTS_YOU_GOT -- %(points)s, %(max_points)s"
 msgstr "You got %(points)s/%(max_points)s for your answer."
 
 #: access/templates/access/async_accepted.html
-msgid "WARNING_GRADING_WAS_SYNCHRONOUS"
-msgstr ""
-"The grading queue is not configured. This submission was graded "
-"synchronously while blocking other services. NOT READY FOR PRODUCTION!"
-
-#: access/templates/access/async_accepted.html
 msgid "ERROR_OCCURED_CONTACT_STAFF"
 msgstr ""
 "An error occurred while handling the submission. Please, contact course "
@@ -125,15 +119,6 @@ msgstr ""
 "when the grading process completes. Note that the grading may take a while. "
 "You might also need to update the page manually in order to see the results. "
 "You may close this message."
-
-#: access/templates/access/async_accepted.html
-#, python-format
-msgid "SUBMISSION_IN_GRADING_QUEUE -- %(queue)s"
-msgstr ""
-"Your submission is in the grading queue. There are %(queue)s other "
-"submissions before. The result will be available on this page when the "
-"grading process completes. The page must be updated manually to see the "
-"results."
 
 #: access/templates/access/course.html
 msgid "SERVICE_URLS_FOR_A+"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MOOC-grader\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-23 10:21+0000\n"
+"POT-Creation-Date: 2023-06-05 13:16+0000\n"
 "PO-Revision-Date: 2019-10-12 20:00+0300\n"
 "Last-Translator: Ella Anttila <ella.anttila@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -92,13 +92,6 @@ msgid "POINTS_YOU_GOT -- %(points)s, %(max_points)s"
 msgstr "Sait %(points)s/%(max_points)s pistettä vastauksestasi."
 
 #: access/templates/access/async_accepted.html
-msgid "WARNING_GRADING_WAS_SYNCHRONOUS"
-msgstr ""
-"Arvostelujonoa ei ole konfiguroitu. Tämä palautus arvosteltiin "
-"synkronisesti, mikä estää muita palveluja toimimasta samaan aikaan. EI "
-"VALMIS TUOTANTOKÄYTTÖÖN!"
-
-#: access/templates/access/async_accepted.html
 msgid "ERROR_OCCURED_CONTACT_STAFF"
 msgstr ""
 "Palautuksen käsittelyssä tapahtui virhe. Ota yhteys kurssihenkilökuntaan."
@@ -124,14 +117,6 @@ msgstr ""
 "kun arvosteluprosessi on suoritettu loppuun. Huomaa, että arvostelu voi "
 "kestää useita kymmeniä sekunteja. Saatat joutua lataamaan tämän sivun "
 "uudelleen nähdäksesi palautteen. Tämän viestin voi sulkea."
-
-#: access/templates/access/async_accepted.html
-#, python-format
-msgid "SUBMISSION_IN_GRADING_QUEUE -- %(queue)s"
-msgstr ""
-"Palautuksesi on arvostelujonossa. Jonossa on edellä %(queue)s palautusta. "
-"Tulos näytetään tällä sivulla, kun arvosteluprosessi on suoritettu. Joudut "
-"lataamaan sivun uudelleen nähdäksesi palautteen."
 
 #: access/templates/access/course.html
 msgid "SERVICE_URLS_FOR_A+"


### PR DESCRIPTION
They seem to be relics from a time the system used celery instead of docker.

The change basically replaces the `wait` and `queue < 3` statements with True, and omits any unreachable code given that.

I only did very basic test of checking that I can still submit things because of how simple the change is.