### PR TITLE
Upgrade from Django 3.2 to 4.2

### DIFF
--- a/access/views.py
+++ b/access/views.py
@@ -37,6 +37,7 @@ from util.auth import (
     login_required,
 )
 from util.log import SecurityLog
+from util.misc import is_ajax
 from util.monitored_dict import MonitoredDict
 from util.personalized import read_generated_exercise_file
 from util.templates import template_to_str
@@ -52,7 +53,7 @@ def index(request):
     '''
     courses = [course for course in config.courses() if has_read_access(request, course["key"])]
 
-    if request.is_ajax():
+    if is_ajax(request):
         return JsonResponse({
             "ready": True,
             "courses": _filter_fields(courses, ["key", "name"])
@@ -239,7 +240,7 @@ def course(request, course_key):
     else:
         if course is None:
             raise Http404()
-    if request.is_ajax():
+    if is_ajax(request):
         if error:
             data = {
                 "ready": False,
@@ -310,7 +311,7 @@ def exercise_ajax(request, course_key, exercise_key):
             raise Http404()
 
         # jQuery does not send "requested with" on cross domain requests
-        #if not request.is_ajax():
+        #if not is_ajax(request):
         #    return HttpResponse('Method not allowed', status=405)
 
         response = import_named(course, exercise['ajax_type'])(request, course, exercise)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django ~= 3.2.13
-git+https://github.com/apluslms/django-essentials.git@1.5.0#egg=django-essentials==1.5.0
+Django ~= 4.2.3
+git+https://github.com/apluslms/django-essentials.git@1.6.0#egg=django-essentials==1.6.0
 requests >= 2.28.0, < 3
 PyYAML ~= 6.0.0
 docutils ~= 0.17.1

--- a/util/misc.py
+++ b/util/misc.py
@@ -1,0 +1,6 @@
+def is_ajax(request):
+    """
+    Detect AJAX requests.
+    Request object method is_ajax() was removed in Django 4.0, this can be used instead.
+    """
+    return request.headers.get('x-requested-with') == 'XMLHttpRequest'


### PR DESCRIPTION
# Description

**What?**

Remove features deprecated and removed in Django version 4.0, 4.1, and 4.2.

**Why?**

Django 4.2 (LTS) was released in April 2023. Django v3.2 reaches end of life in April 2024.

**How?**

I went through the release notes for Django 4.0, 4.1 and 4.2 and checked which deprecated and removed features appear in the codebase and removed/edited them.

Fixes #147

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested for no obvious errors.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
