### PR TITLE
Improve generic feedback on pick-any questions

### DIFF
--- a/access/templatetags/access.py
+++ b/access/templatetags/access.py
@@ -35,4 +35,7 @@ def find_common_hints(list_of_hints, checked):
                     hints_seen.add(hint_value)
                     hints.append(hint_text)
 
+        if list_of_hints.get('points_only_for_fully_correct'):
+            hints.append(list_of_hints.get('points_only_for_fully_correct'))
+
     return hints

--- a/access/types/forms.py
+++ b/access/types/forms.py
@@ -683,6 +683,14 @@ class GradedForm(forms.Form):
             else:
                 hints.append(_('HINT_MULTIPLE_CHOICES_SELECTABLE'))
 
+        if t == "checkbox" and not ok and not configuration.get("partial_points"):
+            # Show this hint in checkbox questions when the answer is not
+            # correct and the partial points option is not set.
+            if checkbox_feedback:
+                hints['points_only_for_fully_correct'] = _('POINTS_AWARDED_ONLY_FOR_FULLY_CORRECT_ANSWERS')
+            else:
+                hints.append(_('POINTS_AWARDED_ONLY_FOR_FULLY_CORRECT_ANSWERS'))
+
         if name in self.fields:
             self.fields[name].grade_points = earned_points
             self.fields[name].max_points = points

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -261,7 +261,14 @@ msgstr ""
 
 #: access/types/forms.py
 msgid "HINT_MULTIPLE_CHOICES_SELECTABLE"
-msgstr "Multiple choices are selectable"
+msgstr "Multiple choices are selectable."
+
+#: access/types/forms.py
+msgid "POINTS_AWARDED_ONLY_FOR_FULLY_CORRECT_ANSWERS"
+msgstr ""
+"Only fully correct answers are awarded with points; the question is meant as "
+"a whole, so no partial points are given. A zero score does not necessarily "
+"mean that your answer was entirely incorrect."
 
 #: access/types/forms.py
 msgid "HINT_MULTIPLE_CORRECT_ANSWERS_ACCEPTED"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -259,7 +259,14 @@ msgstr ""
 
 #: access/types/forms.py
 msgid "HINT_MULTIPLE_CHOICES_SELECTABLE"
-msgstr "Voit valita useita vaihtoehtoja"
+msgstr "Voit valita useita vaihtoehtoja."
+
+#: access/types/forms.py
+msgid "POINTS_AWARDED_ONLY_FOR_FULLY_CORRECT_ANSWERS"
+msgstr ""
+"Vain täysin oikeista vastauksista myönnetään pisteitä; kysymys on "
+"tarkoitettu kokonaisuutena, joten osittaisia pisteitä ei anneta. Nolla "
+"pistettä ei välttämättä tarkoita, että vastauksesi oli täysin väärin."
 
 #: access/types/forms.py
 msgid "HINT_MULTIPLE_CORRECT_ANSWERS_ACCEPTED"


### PR DESCRIPTION
# Description

**What?**

Add an additional feedback note on pick-anys when partial-points option is not used and the answer is incorrect.

![image](https://github.com/apluslms/mooc-grader/assets/38466145/02c7a475-3d1d-4c51-976f-41aa4cd13143)

**Why?**

Students sometimes assume that zero points means “nothing is correct”; moreover, they sometimes expect to get partial credit.

Fixes #150

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the new feedback note only shows in pick-any questions without partial-points option when the answer is incorrect.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
