### PR TITLE
Support placeholder text in questionnaire FreeText fields

### DIFF
--- a/access/types/stdsync.py
+++ b/access/types/stdsync.py
@@ -108,7 +108,7 @@ def createForm(request, course, exercise, post_url):
 
     try:
         form = GradedForm(request.POST or None, request.FILES or None,
-            exercise=exercise, reveal_correct=last, request=request)
+            exercise=exercise, reveal_correct=last, request=request, course=course)
     except PermissionDenied:
         # Randomized forms raise PermissionDenied when the POST data contains
         # forged checksums or samples. It could be cleaner to check those
@@ -155,7 +155,7 @@ def createForm(request, course, exercise, post_url):
 
 
 def createFormModel(request, course, exercise, parameter):
-    form = GradedForm(None, exercise=exercise, model_answer=True)
+    form = GradedForm(None, exercise=exercise, model_answer=True, course=course)
     form.bind_initial()
     points,error_groups,error_fields = form.grade()
     result = {

--- a/util/export.py
+++ b/util/export.py
@@ -126,15 +126,19 @@ def form_fields(languages, exercises):
     def i18n_map(values):
         if all(v == "" for v in values):
             return ""
-        key = str(values[0])
+        key = str(values.copy()[0])
         if key in values[1:]:
             key = "i18n_" + "_".join(key.split())
+        translation_dict = {
+            l: str(v)
+            for l, v in zip(languages, values)
+        }
+        if key in i18n and i18n[key] == translation_dict:
+            # Identical key with the same value already exists, no need to create a duplicate
+            return key
         while key in i18n:
             key += "_duplicate"
-        i18n[key] = {
-            l: v
-            for l,v in zip(languages, values)
-        }
+        i18n[key] = translation_dict
         return key
 
     def field_spec(fs, n):
@@ -173,7 +177,7 @@ def form_fields(languages, exercises):
         if 'extra_info' in f:
             es = list_get(fs, 'extra_info', {})
             extra = es[0]
-            for key in ['validationMessage']:
+            for key in ['validationMessage', 'placeholder']:
                 if key in extra:
                     extra[key] = i18n_map(list_get(es, key, ''))
             field.update(extra)


### PR DESCRIPTION
# Description

**What?**

Add support for `placeholder` value in the FreeText `:extra:` option.

**How to use?**

```
.. freetext:: 5
  :height: 2
  :extra: validationMessage=Please check your answer is correctly formatted;placeholder=This text is shown as a placeholder
```

Fixes apluslms/a-plus#1143

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the placeholder text is shown correctly with multiple languages in both normal questionnaires and MOOC-Jutut questionnaires.
